### PR TITLE
Remove "AWS CIRT" and use "CloudTrail security workshops"

### DIFF
--- a/cloud-operations-best-practices/docs/recipes/AWS CloudTrail/CloudTrail Security/index.md
+++ b/cloud-operations-best-practices/docs/recipes/AWS CloudTrail/CloudTrail Security/index.md
@@ -24,7 +24,7 @@ This section provides comprehensive guidance on leveraging CloudTrail for securi
 
 **[Additional Security Resources](./additional-resources.mdx)**
 - Curated AWS blog posts for incident investigation, monitoring, and automation
-- Hands-on AWS CIRT security workshops for simulating real-world attack scenarios
+- Hands-on CloudTrail security workshops for simulating real-world attack scenarios
 - Tools and scripts for automating CloudTrail analysis and incident response
 
 ### Key Benefits

--- a/cloud-operations-best-practices/docs/recipes/AWS CloudTrail/CloudTrail Security/index.md
+++ b/cloud-operations-best-practices/docs/recipes/AWS CloudTrail/CloudTrail Security/index.md
@@ -24,7 +24,7 @@ This section provides comprehensive guidance on leveraging CloudTrail for securi
 
 **[Additional Security Resources](./additional-resources.mdx)**
 - Curated AWS blog posts for incident investigation, monitoring, and automation
-- Hands-on CloudTrail security workshops for simulating real-world attack scenarios
+- Hands-on AWS CloudTrail security workshops for simulating real-world attack scenarios
 - Tools and scripts for automating CloudTrail analysis and incident response
 
 ### Key Benefits


### PR DESCRIPTION
Removed "AWS CIRT" and use "CloudTrail security workshops" in page Security Incident Response and Forensic Analysis.

* https://aws-samples.github.io/cloud-operations-best-practices/docs/recipes/AWS%20CloudTrail/CloudTrail%20Security/