### PR TITLE
feat(FloatingBanner): Add tracking parameters to CloudOps events link

### DIFF
--- a/cloud-operations-best-practices/src/components/FloatingBanner.js
+++ b/cloud-operations-best-practices/src/components/FloatingBanner.js
@@ -45,7 +45,7 @@ export default function FloatingBanner() {
       <span>Live:</span>
       <span>CloudOps Webinars &amp; Hands-on Workshops ·</span>
       <a
-        href="https://aws-experience.com/amer/smb/events/series/Cloud-Operations-Enablement"
+        href="https://aws-experience.com/amer/smb/events/series/Cloud-Operations-Enablement?trk=058158e6-5e99-4d98-9f55-296ec1c966d2&sc_channel=el"
         target="_blank"
         rel="noopener noreferrer"
         style={linkStyle}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add UTM tracking parameters to CloudOps Webinars event series URL
- Include trk and sc_channel query parameters for analytics
- Enables better event registration tracking and campaign attribution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
